### PR TITLE
[RD-36217] Reduced sleep time in _wait_for_result

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The purpose is to provide a python client to connect to the debugger tools of a 
 
 **Currently supports** connecting to **Google-Chrome/Chromium** over the devtools protocol, via a wrapped websockets client. **Feel free to extend and add support for other browsers** as required.
 
+For improved performance, install the wsaccel python lib https://pypi.org/project/wsaccel/
+
 ## Example Usage
 
 Start Google-Chrome, passing a remote debugger port argument, for example on Ubuntu:

--- a/browserdebuggertools/sockethandler.py
+++ b/browserdebuggertools/sockethandler.py
@@ -196,7 +196,7 @@ class SocketHandler(object):
             try:
                 return self._find_next_result()
             except ResultNotFoundError:
-                time.sleep(0.5)
+                time.sleep(0.01)
         raise DevToolsTimeoutException(
             "Reached timeout limit of {}, waiting for a response message".format(self.timeout)
         )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="5.0.0",
+    version="5.0.1",
     packages=PACKAGES,
     install_requires=requires,
     license="GNU General Public License v3",


### PR DESCRIPTION
- Decreasing the sleep time in _wait_for_result decreases the total time
  a user spends waiting for execute operations, but is still enough to
  prevent 1 CPU core from being signficantly utilised by a single
  call of _wait_for_result.
- Bumped patch version
- Updated README