### PR TITLE
Track page load events to be able to allow caching

### DIFF
--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -28,7 +28,7 @@ class ChromeInterface(object):
         :param domains: Dictionary of dictionaries where the Key is the domain string and the Value
         is a dictionary of the arguments passed with the domain upon enabling.
         """
-        self._socket_handler = SocketHandler(port, timeout, domains=domains)
+        self._socket_handler = SocketHandler(port, timeout, domains=domains)  # type: SocketHandler
 
     def quit(self):
         self._socket_handler.close()
@@ -107,8 +107,11 @@ class ChromeInterface(object):
         return result.get("value")
 
     def get_url(self):
-        """ Returns the current url of the page.
-            Consider enabling the Page domain to increase performance.
+        # type: () -> str
+        """
+        Consider enabling the Page domain to increase performance.
+
+        :returns: The url of the current page.
         """
         return self._socket_handler.event_handlers["PageLoad"].get_current_url()
 
@@ -118,8 +121,11 @@ class ChromeInterface(object):
         return self.execute_javascript("document.readyState")
 
     def get_page_source(self):
-        """ Returns a string serialization of the active document's DOM.
-            Consider enabling the Page domain to increase performance.
+        # type: () -> str
+        """
+        Consider enabling the Page domain to increase performance.
+
+        :returns: A string serialization of the active document's DOM.
         """
         root_node_id = self._socket_handler.event_handlers["PageLoad"].get_root_node_id()
 

--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -29,6 +29,8 @@ class ChromeInterface(object):
         is a dictionary of the arguments passed with the domain upon enabling.
         """
         self._socket_handler = SocketHandler(port, timeout, domains=domains)
+        self._backend_node_id = None
+        self._current_url = None
 
     def quit(self):
         self._socket_handler.close()
@@ -106,8 +108,28 @@ class ChromeInterface(object):
 
         return result.get("value")
 
+    def check_page_has_changed(self):
+        self._socket_handler.flush_messages()
+        url_changed = self._socket_handler.internal_events['Page']['domContentEventFired']
+        if url_changed:
+            logging.info("OLD URL was %s" % self._current_url)
+            self._current_url = None
+            self._backend_node_id = None
+            self._socket_handler.internal_events['Page']['domContentEventFired'] = []
+
+        if self._current_url is None:
+            print("Retrieving new URL")
+            root = self.execute("DOM", "getDocument", {"depth": 0})["root"]
+            self._current_url = root["documentURL"]
+            self._backend_node_id = root["backendNodeId"]
+
     def get_url(self):
-        return self.execute_javascript("document.URL")
+        if "Page" in self._socket_handler.domains:
+            self.check_page_has_changed()
+            return self._current_url
+        else:
+            print("Page not enabled")
+            return self.execute("DOM", "getDocument", {"depth": 0})["root"]["documentURL"]
 
     def get_document_readystate(self):
         """ Gets the document.readyState of the page.
@@ -117,7 +139,14 @@ class ChromeInterface(object):
     def get_page_source(self):
         """ Returns a string serialization of the active document's DOM
         """
-        return self.execute_javascript("document.documentElement.innerHTML")
+        if "Page" in self._socket_handler.domains:
+            self.check_page_has_changed()
+            root_node_id = self._backend_node_id
+        else:
+            print("Page not enabled")
+            root_node_id = self.execute("DOM", "getDocument", {"depth": 0})["root"]["backendNodeId"]
+
+        return self.execute("DOM", "getOuterHTML", {"backendNodeId": root_node_id})["outerHTML"]
 
     def set_user_agent_override(self, user_agent):
         """ Overriding user agent with the given string.

--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -107,10 +107,10 @@ class ChromeInterface(object):
         return result.get("value")
 
     def get_url(self):
-        if "Page" in self._socket_handler._domains:
-            return self._socket_handler.event_handlers["PageLoad"].get_current_url()
-        else:
-            return self.execute("DOM", "getDocument", {"depth": 0})["root"]["documentURL"]
+        """ Returns the current url of the page.
+            Consider enabling the Page domain to increase performance.
+        """
+        return self._socket_handler.event_handlers["PageLoad"].get_current_url()
 
     def get_document_readystate(self):
         """ Gets the document.readyState of the page.
@@ -118,13 +118,10 @@ class ChromeInterface(object):
         return self.execute_javascript("document.readyState")
 
     def get_page_source(self):
-        """ Returns a string serialization of the active document's DOM
+        """ Returns a string serialization of the active document's DOM.
+            Consider enabling the Page domain to increase performance.
         """
-        root_node_id = None
-        if "Page" in self._socket_handler._domains:
-            root_node_id = self._socket_handler.event_handlers["PageLoad"].get_root_node_id()
-        else:
-            root_node_id = self.execute("DOM", "getDocument", {"depth": 0})["root"]["backendNodeId"]
+        root_node_id = self._socket_handler.event_handlers["PageLoad"].get_root_node_id()
 
         return self.execute("DOM", "getOuterHTML", {"backendNodeId": root_node_id})["outerHTML"]
 

--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -127,9 +127,7 @@ class ChromeInterface(object):
 
         :returns: A string serialization of the active document's DOM.
         """
-        root_node_id = self._socket_handler.event_handlers["PageLoad"].get_root_node_id()
-
-        return self.execute("DOM", "getOuterHTML", {"backendNodeId": root_node_id})["outerHTML"]
+        return self._socket_handler.event_handlers["PageLoad"].get_page_source()
 
     def set_user_agent_override(self, user_agent):
         """ Overriding user agent with the given string.

--- a/browserdebuggertools/eventhandlers.py
+++ b/browserdebuggertools/eventhandlers.py
@@ -52,6 +52,8 @@ class PageLoadEventHandler(EventHandler):
         self.check_page_load()
         return self._url
 
-    def get_root_node_id(self):
+    def get_page_source(self):
         self.check_page_load()
-        return self._root_node_id
+        return self._socket_handler.execute(
+            "DOM", "getOuterHTML", {"backendNodeId": self._root_node_id}
+        )["outerHTML"]

--- a/browserdebuggertools/eventhandlers.py
+++ b/browserdebuggertools/eventhandlers.py
@@ -1,0 +1,54 @@
+import logging
+from abc import ABCMeta, abstractmethod
+
+logging.basicConfig(format='%(levelname)s:%(message)s')
+
+
+class EventHandler(object):
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, socket_handler):
+        self._socket_handler = socket_handler
+
+    @abstractmethod
+    def handle(self, message):
+        pass
+
+
+class PageLoadEventHandler(EventHandler):
+
+    def __init__(self, socket_handler):
+        super(PageLoadEventHandler, self).__init__(socket_handler)
+        self._socket_handler = socket_handler
+        self._url = None
+        self._root_node_id = None
+
+    def handle(self, message):
+        super(PageLoadEventHandler, self).handle(message)
+        if message.get("method") == "Page.navigatedWithinDocument":
+            logging.info("Detected URL change %s" % message["params"]["url"])
+            self._url = message["params"]["url"]
+        else:
+            logging.info("Detected Page Load")
+            self.reset()
+
+    def reset(self):
+        self._url = None
+        self._root_node_id = None
+
+    def check_page_load(self):
+        self._socket_handler._flush_messages()
+        if self._root_node_id is None:
+            logging.info("Retrieving new page data")
+            root = self._socket_handler.execute("DOM", "getDocument", {"depth": 0})["root"]
+            self._url = root["documentURL"]
+            self._root_node_id = root["backendNodeId"]
+
+    def get_current_url(self):
+        self.check_page_load()
+        return self._url
+
+    def get_root_node_id(self):
+        self.check_page_load()
+        return self._root_node_id

--- a/browserdebuggertools/eventhandlers.py
+++ b/browserdebuggertools/eventhandlers.py
@@ -28,7 +28,7 @@ class PageLoadEventHandler(EventHandler):
         if message.get("method") == "Page.navigatedWithinDocument":
             logging.info("Detected URL change %s" % message["params"]["url"])
             self._url = message["params"]["url"]
-        else:
+        elif message.get("method") == "Page.domContentEventFired":
             logging.info("Detected Page Load")
             self._reset()
 

--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -6,11 +6,15 @@ class ProtocolError(DevToolsException):
     pass
 
 
+class NotFoundError(DevToolsException):
+    pass
+
+
 class DevToolsTimeoutException(DevToolsException):
     pass
 
 
-class TabNotFoundError(DevToolsException):
+class TabNotFoundError(NotFoundError):
     pass
 
 
@@ -18,11 +22,9 @@ class DomainNotEnabledError(DevToolsException):
     pass
 
 
-class DomainNotFoundError(ProtocolError):
+class DomainNotFoundError(ProtocolError, NotFoundError):
     pass
 
 
-class ResultNotFoundError(DevToolsException):
+class ResultNotFoundError(NotFoundError):
     pass
-
-

--- a/browserdebuggertools/sockethandler.py
+++ b/browserdebuggertools/sockethandler.py
@@ -163,13 +163,13 @@ class SocketHandler(object):
 
         return self._results.pop(self._next_result_id)
 
-    def execute(self, domainName, methodName, params=None):
+    def execute(self, domain_name, method_name, params=None):
 
         if params is None:
             params = {}
 
         self._next_result_id += 1
-        method = "{}.{}".format(domainName, methodName)
+        method = "{}.{}".format(domain_name, method_name)
         self._send({
             "method": method, "params": params
         })
@@ -216,25 +216,25 @@ class SocketHandler(object):
             "Reached timeout limit of {}, waiting for a response message".format(self.timeout)
         )
 
-    def enable_domain(self, domainName, parameters=None):
+    def enable_domain(self, domain_name, parameters=None):
 
         if not parameters:
             parameters = {}
 
-        self._add_domain(domainName, parameters)
-        result = self.execute(domainName, "enable", parameters)
+        self._add_domain(domain_name, parameters)
+        result = self.execute(domain_name, "enable", parameters)
         if "error" in result:
-            self._remove_domain(domainName)
-            raise DomainNotFoundError("Domain \"{}\" not found.".format(domainName))
+            self._remove_domain(domain_name)
+            raise DomainNotFoundError("Domain \"{}\" not found.".format(domain_name))
 
-        logging.info("\"{}\" domain has been enabled".format(domainName))
+        logging.info("\"{}\" domain has been enabled".format(domain_name))
 
-    def disable_domain(self, domainName):
+    def disable_domain(self, domain_name):
         """ Disables further notifications from the given domain.
         """
-        self._remove_domain(domainName)
-        result = self.execute(domainName, "disable", {})
+        self._remove_domain(domain_name)
+        result = self.execute(domain_name, "disable", {})
         if "error" in result:
-            logging.warn("Domain \"{}\" doesn't exist".format(domainName))
+            logging.warn("Domain \"{}\" doesn't exist".format(domain_name))
         else:
-            logging.info("Domain {} has been disabled".format(domainName))
+            logging.info("Domain {} has been disabled".format(domain_name))

--- a/browserdebuggertools/sockethandler.py
+++ b/browserdebuggertools/sockethandler.py
@@ -196,6 +196,7 @@ class SocketHandler(object):
         if clear:
             self._events[domain] = []
         else:
+            # This is to make the events immutable unless using clear
             events = events[:]
 
         return events

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="5.0.0",
+    version="5.1.0",
     packages=PACKAGES,
     install_requires=requires,
     license="GNU General Public License v3",

--- a/tests/e2etests/chrome/test_interface.py
+++ b/tests/e2etests/chrome/test_interface.py
@@ -289,7 +289,7 @@ class Test_ChromeInterface_set_baic_auth_headless(
     pass
 
 
-class ChromeInterface_connection_unexpectadely_closed(object):
+class ChromeInterface_connection_unexpectedely_closed(object):
 
     def test(self):
 
@@ -308,12 +308,69 @@ class ChromeInterface_connection_unexpectadely_closed(object):
 
 
 class Test_ChromeInterface_connection_unexpectadely_closed_headed(
-    HeadedChromeInterfaceTest, ChromeInterface_connection_unexpectadely_closed, TestCase
+    HeadedChromeInterfaceTest, ChromeInterface_connection_unexpectedely_closed, TestCase
 ):
     pass
 
 
 class Test_ChromeInterface_connection_unexpectadely_closed_headless(
-    HeadlessChromeInterfaceTest, ChromeInterface_connection_unexpectadely_closed, TestCase
+    HeadlessChromeInterfaceTest, ChromeInterface_connection_unexpectedely_closed, TestCase
+):
+    pass
+
+
+class ChromeInterface_cache_page(object):
+
+    def test_with_page(self):
+
+        assert isinstance(self, ChromeInterfaceTest)
+
+        self.devtools_client.enable_domain("Page")
+
+        base_url = "http://localhost:%s/" % self.testSite.port
+
+        simple_page = "<html><head></head><body><h1>Simple Page</h1></body></html>"
+        simple_page_2 = "<html><head></head><body><h1>Simple Page 2</h1></body></html>"
+
+        fake_page_load = "<script>" \
+                         "function fake_page_load(){" \
+                         "document.getElementById('title-text').innerHTML= 'Fake Title';" \
+                         "window.history.pushState('fake_page', 'Fake Title', '/fake_page');" \
+                         "}" \
+                         "</script>"
+
+        simple_page_3 = '<html><head></head><body><h1 id="title-text">Simple Page 3</h1>%' \
+                        's</body></html>' % fake_page_load
+        fake_page = '<html><head></head><body><h1 id="title-text">Fake Title</h1>' \
+                    '%s</body></html>' % fake_page_load
+
+        # Test caching without page loads (low 3 calls)
+        self.devtools_client.navigate(base_url + "simple_page")
+        self.assertEqual(base_url + "simple_page", self.devtools_client.get_url())
+        self.assertEqual(simple_page, self.devtools_client.get_page_source())
+        self.assertEqual(base_url + "simple_page", self.devtools_client.get_url())
+        self.assertEqual(simple_page, self.devtools_client.get_page_source())
+
+        # Test caching with page loads (low 2 calls)
+        self.devtools_client.navigate(base_url + "simple_page_2")
+        self.devtools_client.navigate(base_url + "fake_load_page")
+        self.assertEqual(base_url + "fake_load_page", self.devtools_client.get_url())
+        self.assertEqual(simple_page_3, self.devtools_client.get_page_source())
+
+        # Test caching with javascript page loads (low 1 call)
+        self.devtools_client.execute_javascript("fake_page_load()")
+
+        self.assertEqual(base_url + "fake_page", self.devtools_client.get_url())
+        self.assertEqual(fake_page, self.devtools_client.get_page_source())
+
+
+class Test_ChromeInterface_cache_page_headed(
+    HeadedChromeInterfaceTest, ChromeInterface_cache_page, TestCase
+):
+    pass
+
+
+class Test_ChromeInterface_cache_page_headless(
+    HeadlessChromeInterfaceTest, ChromeInterface_cache_page, TestCase
 ):
     pass

--- a/tests/e2etests/testsite/start.py
+++ b/tests/e2etests/testsite/start.py
@@ -70,6 +70,25 @@ class TestSite(object):
                 return True
         return False
 
+    @cherrypy.expose
+    def simple_page(self):
+        return "<html><head></head><body><h1>Simple Page</h1></body></html>"
+
+    @cherrypy.expose
+    def simple_page_2(self):
+        return "<html><head></head><body><h1>Simple Page 2</h1></body></html>"
+
+    @cherrypy.expose
+    def fake_load_page(self):
+        fake_page_script = "<script>" \
+                         "function fake_page_load(){" \
+                            "document.getElementById('title-text').innerHTML= 'Fake Title';" \
+                            "window.history.pushState('fake_page', 'Fake Title', '/fake_page');" \
+                         "}" \
+                         "</script>"
+        return "<html><head></head><body><h1 id='title-text'>Simple Page 3</h1>" \
+               "%s</body></html>" % fake_page_script
+
 
 class Server(object):
 

--- a/tests/integrationtests/chrome/test_interface.py
+++ b/tests/integrationtests/chrome/test_interface.py
@@ -7,6 +7,7 @@ from mock import MagicMock, patch
 
 from browserdebuggertools.chrome.interface import ChromeInterface
 from browserdebuggertools.exceptions import DevToolsTimeoutException
+from browserdebuggertools.sockethandler import SocketHandler
 
 MODULE_PATH = "browserdebuggertools.chrome.interface."
 
@@ -14,8 +15,16 @@ MODULE_PATH = "browserdebuggertools.chrome.interface."
 class MockChromeInterface(ChromeInterface):
 
     def __init__(self, port, timeout=30, domains=None):
-        self.timeout = timeout
-        self._socket_handler = MagicMock()
+        self._socket_handler = MockSocketHandler(port, timeout, domains=domains)
+
+
+class MockSocketHandler(SocketHandler):
+
+    def _setup_websocket(self):
+        return MagicMock()
+
+    def _get_websocket_url(self, port):
+        return MagicMock()
 
 
 @patch(MODULE_PATH + "ChromeInterface.execute")
@@ -41,21 +50,70 @@ class Test_ChromeInterface_take_screenshot(TestCase):
             os.remove(self.file_path)
 
 
-@patch(MODULE_PATH + "SocketHandler._setup_websocket", MagicMock())
-@patch(MODULE_PATH + "SocketHandler._get_websocket_url", MagicMock())
-class Test_ChromeInterface_set_timeout(TestCase):
+class ChromeInterfaceTest(TestCase):
+
+    def setUp(self):
+        self.interface = MockChromeInterface(0)
+        self.interface._socket_handler._websocket.send = MagicMock()
+
+
+
+class Test_ChromeInterface_set_timeout(ChromeInterfaceTest):
 
     def test_timeout_exception_raised(self):
-
-        interface = ChromeInterface(0)
-        interface._socket_handler._websocket.send = MagicMock()
-        interface._socket_handler._websocket.recv = MagicMock(return_value=None)
+        self.interface._socket_handler._websocket.send = MagicMock()
+        self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
 
         start = time.time()
         with self.assertRaises(DevToolsTimeoutException):
-            with interface.set_timeout(3):
-                interface.execute("Something", "Else")
+            with self.interface.set_timeout(3):
+                self.interface.execute("Something", "Else")
 
         elapsed = time.time() - start
         self.assertGreaterEqual(elapsed, 2.5)
         self.assertLessEqual(elapsed, 3.4)
+
+
+class Test_ChromeInterface_get_url(ChromeInterfaceTest):
+
+    def load_pages(self, count):
+        mock_message = '{"method": "Page.domContentEventFired"}'
+        messages = [None]
+        for _ in range(count):
+            messages.insert(0, mock_message)
+        self.interface._socket_handler._websocket.recv.side_effect = messages
+
+    def load_js_pages(self, count):
+        mock_message = '{"method": "Page.navigatedWithinDocument", "params":{"url": ""}}'
+        messages = [None]
+        for _ in range(count):
+            messages.insert(0, mock_message)
+        self.interface._socket_handler._websocket.recv.side_effect = messages
+
+    def test_page_enabled_cache(self):
+        self.interface._socket_handler._domains["Page"] = {}
+        self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
+        self.interface._socket_handler.execute = MagicMock()
+
+        self.interface.get_url()
+        self.interface.get_page_source()
+        self.assertEqual(2, self.interface._socket_handler.execute.call_count)
+        self.interface.get_url()
+        self.interface.get_page_source()
+        self.assertEqual(3, self.interface._socket_handler.execute.call_count)
+
+        self.load_pages(2)
+        self.assertEqual(3, self.interface._socket_handler.execute.call_count)
+
+        self.interface.get_url()
+        self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
+        self.interface.get_page_source()
+        self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
+        self.assertEqual(5, self.interface._socket_handler.execute.call_count)
+
+        self.load_js_pages(1)
+        self.interface.get_url()
+        self.assertEqual(5, self.interface._socket_handler.execute.call_count)
+        self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
+        self.interface.get_page_source()
+        self.assertEqual(6, self.interface._socket_handler.execute.call_count)

--- a/tests/integrationtests/chrome/test_interface.py
+++ b/tests/integrationtests/chrome/test_interface.py
@@ -92,6 +92,7 @@ class Test_ChromeInterface_get_url(ChromeInterfaceTest):
 
     def test_page_enabled_cache(self):
         self.interface._socket_handler._domains["Page"] = {}
+        self.interface._socket_handler._events["Page"] = []
         self.interface._socket_handler._websocket.recv = MagicMock(return_value=None)
         self.interface._socket_handler.execute = MagicMock()
 

--- a/tests/integrationtests/test_sockethandler.py
+++ b/tests/integrationtests/test_sockethandler.py
@@ -82,3 +82,36 @@ class Test_SocketHandler_can_get_messages(SocketHandlerTest):
         self.socket_handler._flush_messages()
 
         self.assertEqual(mock_result, self.socket_handler._results[1])
+
+
+class Test_SocketHandler_get_events(SocketHandlerTest):
+
+    def test_get_events_returns_copy(self):
+        mock_message = '{"method": "MockDomain.mockEvent", "params": {"key": "value"}}'
+        self.socket_handler._domains = ["MockDomain"]
+        self.socket_handler._events["MockDomain"] = []
+        self.socket_handler._websocket.recv.side_effect = [mock_message, None, None]
+
+        events = self.socket_handler.get_events("MockDomain")
+
+        events[0] = ""
+
+        self.assertEqual(
+            {"method": "MockDomain.mockEvent", "params": {"key": "value"}},
+            self.socket_handler.get_events("MockDomain")[0]
+        )
+
+    def test_get_events_clear(self):
+        mock_message = '{"method": "MockDomain.mockEvent", "params": {"key": "value"}}'
+        self.socket_handler._domains = ["MockDomain"]
+        self.socket_handler._events["MockDomain"] = []
+        self.socket_handler._websocket.recv.side_effect = [mock_message, None, None]
+
+        events = self.socket_handler.get_events("MockDomain")
+
+        events[0] = ""
+
+        self.assertEqual(
+            {"method": "MockDomain.mockEvent", "params": {"key": "value"}},
+            self.socket_handler.get_events("MockDomain")[0]
+        )

--- a/tests/integrationtests/test_sockethandler.py
+++ b/tests/integrationtests/test_sockethandler.py
@@ -17,6 +17,7 @@ class MockSocketHandler(SocketHandler):
         self._domains = []
         self._results = {}
         self._events = {}
+        self._internal_events = {}
 
 
 class SocketHandlerTest(TestCase):

--- a/tests/unittests/test_eventhandlers.py
+++ b/tests/unittests/test_eventhandlers.py
@@ -9,15 +9,14 @@ from browserdebuggertools.exceptions import DomainNotEnabledError
 class PageLoadEventHandlerTest(TestCase):
 
     def setUp(self):
-        socket_handler = MagicMock()
-        self.event_handler = PageLoadEventHandler(socket_handler)
+        self.event_handler = PageLoadEventHandler(socket_handler=MagicMock())
 
 
 class Test_PageLoadEventHandler_handle(PageLoadEventHandlerTest):
 
     def test_url_change(self):
         mock_url = "url.com"
-        mock_message = {"method": "Page.navigatedWithinDocument", "params":{"url": mock_url}}
+        mock_message = {"method": "Page.navigatedWithinDocument", "params": {"url": mock_url}}
 
         self.event_handler.handle(mock_message)
 

--- a/tests/unittests/test_eventhandlers.py
+++ b/tests/unittests/test_eventhandlers.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from mock import MagicMock
+
+from browserdebuggertools.eventhandlers import PageLoadEventHandler
+from browserdebuggertools.exceptions import DomainNotEnabledError
+
+
+class PageLoadEventHandlerTest(TestCase):
+
+    def setUp(self):
+        socket_handler = MagicMock()
+        self.event_handler = PageLoadEventHandler(socket_handler)
+
+
+class Test_PageLoadEventHandler_handle(PageLoadEventHandlerTest):
+
+    def test_url_change(self):
+        mock_url = "url.com"
+        mock_message = {"method": "Page.navigatedWithinDocument", "params":{"url": mock_url}}
+
+        self.event_handler.handle(mock_message)
+
+        self.assertEqual(mock_url, self.event_handler._url)
+
+    def test_page_change(self):
+        mock_message = {"method": "Page.domContentEventFired", "params": {}}
+
+        self.event_handler.handle(mock_message)
+
+        self.assertIsNone(self.event_handler._url)
+        self.assertIsNone(self.event_handler._root_node_id)
+
+
+class Test_PageLoadEventHandler_check_page_load(PageLoadEventHandlerTest):
+
+    def test_Page_domain_not_enabled(self):
+        mock_doc_url, mock_root_node_id = "doc.url", 999
+        mock_response = {"root": {"documentURL": mock_doc_url, "backendNodeId": mock_root_node_id}}
+        self.event_handler._socket_handler.get_events.side_effect = DomainNotEnabledError
+        self.event_handler._socket_handler.execute.return_value = mock_response
+
+        self.event_handler.check_page_load()
+
+        self.assertEqual(mock_doc_url, self.event_handler._url)
+        self.assertEqual(mock_root_node_id, self.event_handler._root_node_id)


### PR DESCRIPTION
* Adds event handlers to allow us to cache the pages URL and faster retrieval of the page source.
* Get's the page source directly from the browser rather than through javascript.