### PR TITLE
[RD-35599] Removed set_basic_auth method

### DIFF
--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -165,14 +165,6 @@ class ChromeInterface(object):
 
         return self.execute("Network", "emulateNetworkConditions", network_conditions)
 
-    def set_basic_auth(self, username, password):
-        """
-        Creates a basic type Authorization header from the username and password strings
-        and applies it to all requests
-        """
-        auth = "Basic " + b64encode("%s:%s" % (username, password))
-        self.set_request_headers({"Authorization": auth})
-
     def set_request_headers(self, headers):
         """
         The specified headers are applied to all requests

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="5.1.0",
+    version="6.1.0",
     packages=PACKAGES,
     install_requires=requires,
     license="GNU General Public License v3",

--- a/tests/e2etests/chrome/test_interface.py
+++ b/tests/e2etests/chrome/test_interface.py
@@ -262,36 +262,6 @@ class Test_ChromeInterface_emulate_network_conditions_headless(
     pass
 
 
-class ChromeInterface_set_basic_auth(object):
-
-    def test_standard_auth_page(self):
-
-        assert isinstance(self, ChromeInterfaceTest)
-
-        self.devtools_client.enable_domain("Network")
-        url = "http://username:password@localhost:%s/auth_challenge" % self.testSite.port
-        self.devtools_client.navigate(url=url)
-        self._assert_dom_complete()
-
-        responses_received = self._get_responses_received()
-
-        self.assertTrue(len(responses_received) >= 2)  # Headed browser creates extra requests
-        self.assertIn(200, responses_received)
-        self.assertNotIn(401, responses_received)  # Devtools genuinely doesn't report these
-
-
-class Test_ChromeInterface_set_baic_auth_headed(
-    HeadedChromeInterfaceTest, ChromeInterface_set_basic_auth, TestCase
-):
-    pass
-
-
-class Test_ChromeInterface_set_baic_auth_headless(
-    HeadlessChromeInterfaceTest, ChromeInterface_set_basic_auth, TestCase
-):
-    pass
-
-
 class ChromeInterface_connection_unexpectedely_closed(object):
 
     def test(self):


### PR DESCRIPTION
- Overriding headers is not a good way to set basic auth, as it gets
  applied to every domain. Users should instead be using
  request interceptions to respond to auth prompts.