### PR TITLE
[RD-37645] Removed validation of xpaths, and dep lxml

### DIFF
--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -2,9 +2,7 @@ import contextlib
 import logging
 from base64 import b64decode, b64encode
 
-from lxml.etree import XPath, XPathSyntaxError
-
-from browserdebuggertools.exceptions import InvalidXPathError, ResourceNotFoundError
+from browserdebuggertools.exceptions import ResourceNotFoundError
 from browserdebuggertools.sockethandler import SocketHandler
 
 
@@ -196,17 +194,9 @@ class ChromeInterface(object):
 
         :param xpath: following the spec 3.1 https://www.w3.org/TR/xpath-31/
         :return: HTML markup
-        :raises XPathSyntaxError: The given xpath is invalid
         :raises IFrameNotFoundError: A matching iframe document could not be found
         :raises UnknownError: The socket handler received a message with an unknown error code
         """
-
-        try:
-            XPath(xpath)  # Validates the xpath
-
-        except XPathSyntaxError:
-            raise InvalidXPathError("{0} is not a valid xpath".format(xpath))
-
         return self._dom_manager.get_iframe_html(xpath)
 
     def get_page_source(self):

--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -46,9 +46,5 @@ class MaxRetriesException(DevToolsException):
     pass
 
 
-class InvalidXPathError(DevToolsException):
-    pass
-
-
 class UnknownError(ProtocolError):
     pass

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,6 +2,5 @@ requests
 mock
 typing
 jinja2
-lxml
 websocket-client==0.56
 cherrypy==17.4.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ requires = [
         "requests",
         "websocket-client",
         "typing",
-        "lxml"
 ]
 
 
@@ -13,7 +12,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="5.2.0",
+    version="5.3.0",
     packages=PACKAGES,
     install_requires=requires,
     license="GNU General Public License v3",

--- a/tests/e2etests/chrome/test_interface.py
+++ b/tests/e2etests/chrome/test_interface.py
@@ -9,7 +9,7 @@ from requests import ConnectionError
 
 from browserdebuggertools.exceptions import (
     DevToolsException, DevToolsTimeoutException, JavascriptDialogNotFoundError,
-    InvalidXPathError, ResourceNotFoundError
+    ResourceNotFoundError
 )
 from browserdebuggertools.models import JavascriptDialog
 from tests.e2etests.testsite.start import Server as TestSiteServer, env
@@ -583,13 +583,6 @@ class Test_ChromeInterface_test_get_iframe_source_content(object):
 
         with self.assertRaises(ResourceNotFoundError):
             self.devtools_client.get_iframe_source_content("//div")
-
-    def test_invalid_xpath(self):
-
-        assert isinstance(self, (ChromeInterfaceTest, TestCase))
-
-        with self.assertRaises(InvalidXPathError):
-            self.devtools_client.get_iframe_source_content("@@")
 
 
 class Test_ChromeInterface_test_get_frame_html_headed(


### PR DESCRIPTION
- lxml depends on two system libraries, and this seems like too many
  requirements for a single validation. Let the user validate xpaths
  before they pass them to get_iframe_source_content.
- bumped minor version. No breaking interface changes, but the
  user shouldn't expect to catch InvalidXPathError anymore.