### PR TITLE
Bug/rd 41105 handle concurrency issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ addons:
   chrome: stable
 language: python
 python:
-  - "2.7"
-  - "3.5"
+  - "3.8"
 env:
   global:
     - DEFAULT_CHROME_BROWSER_PATH=google-chrome-stable

--- a/browserdebuggertools/eventhandlers.py
+++ b/browserdebuggertools/eventhandlers.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from typing import Optional
 
 from browserdebuggertools.exceptions import (
-    DomainNotEnabledError, JavascriptDialogNotFoundError, DevToolsException
+    JavascriptDialogNotFoundError, DevToolsException
 )
 from browserdebuggertools.models import JavascriptDialog
 
@@ -52,9 +52,7 @@ class PageLoadEventHandler(EventHandler):
         self._root_node_id = None
 
     def check_page_load(self):
-        try:
-            self._socket_handler.get_events("Page")
-        except DomainNotEnabledError:
+        if not self._socket_handler.is_domain_enabled("Page"):
             self._reset()
 
         if self._root_node_id is None:
@@ -97,7 +95,6 @@ class JavascriptDialogEventHandler(EventHandler):
         :return JavascriptDialog:
         :raises JavascriptDialogNotFoundError:
         """
-        self._socket_handler.get_events("Page")
         # Instead of setting self._dialog to None we switch the handled property so that we
         # change the handled property for all instances of the object,
         # hence why we check both conditions.

--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -26,10 +26,6 @@ class MethodNotFoundError(ProtocolError, NotFoundError):
     pass
 
 
-class MessageNotFoundError(NotFoundError):
-    pass
-
-
 class ResourceNotFoundError(NotFoundError):
     pass
 

--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -1,3 +1,6 @@
+from websocket import WebSocketException
+
+
 class DevToolsException(Exception):
     pass
 
@@ -47,4 +50,8 @@ class MessagingThreadIsDeadError(DevToolsException):
 
 
 class InvalidParametersError(ProtocolError):
+    pass
+
+
+class WebSocketBlockedException(WebSocketException, DevToolsException):
     pass

--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -26,7 +26,7 @@ class MethodNotFoundError(ProtocolError, NotFoundError):
     pass
 
 
-class ResultNotFoundError(NotFoundError):
+class MessageNotFoundError(NotFoundError):
     pass
 
 

--- a/browserdebuggertools/wssessionmanager.py
+++ b/browserdebuggertools/wssessionmanager.py
@@ -246,7 +246,8 @@ class WSSessionManager(object):
 
         self._message_producer = None
 
-        self._message_consumer = Thread(target=self._flush_messages, daemon=True)
+        self._message_consumer = Thread(target=self._flush_messages)
+        self._message_consumer.daemon = True
         self._events_access_lock = Lock()
         self._should_flush_messages = True
         self._exception = None

--- a/browserdebuggertools/wssessionmanager.py
+++ b/browserdebuggertools/wssessionmanager.py
@@ -5,7 +5,7 @@ import socket
 import time
 import collections
 from datetime import datetime
-from threading import Thread, Event
+from threading import Thread, Event, Lock
 
 from typing import Dict
 
@@ -181,6 +181,8 @@ class WSSessionManager(object):
             }
         }  # type: Dict[str, Dict[str, EventHandler]]
         self._next_result_id = 0
+        self._result_id_lock = Lock()
+
         self._last_not_ok = None
         self._messaging_thread_not_ok_count = 0
 
@@ -249,7 +251,6 @@ class WSSessionManager(object):
 
     def _send(self, data):
         self._check_messaging_thread()
-        data['id'] = self._next_result_id
         self.messaging_thread.add_to_send_queue(json.dumps(data, sort_keys=True))
         self._poll_signal.set()
 
@@ -300,29 +301,33 @@ class WSSessionManager(object):
         if timer.timed_out and message:
             raise DevToolsTimeoutException("Timed out flushing messages after %ss" % timer.timeout)
 
-    def _find_next_result(self):
-        if self._next_result_id not in self._results:
+    def _find_next_result(self, result_id):
+        if result_id not in self._results:
             self._flush_messages()
 
-        if self._next_result_id not in self._results:
-            raise ResultNotFoundError("Result not found for id: {} .".format(self._next_result_id))
+        if result_id not in self._results:
+            raise ResultNotFoundError("Result not found for id: {} .".format(result_id))
 
-        return self._results.pop(self._next_result_id)
+        return self._results.pop(result_id)
 
     def _execute(self, domain_name, method_name, params=None):
 
         if params is None:
             params = {}
 
-        self._next_result_id += 1
+        with self._result_id_lock:
+            self._next_result_id += 1
+            result_id = self._next_result_id
+
         method = "{}.{}".format(domain_name, method_name)
         self._send({
-            "method": method, "params": params
+            "id": result_id, "method": method, "params": params
         })
+        return result_id
 
     def execute(self, domain_name, method_name, params=None):
-        self._execute(domain_name, method_name, params)
-        result = self._wait_for_result()
+        result_id = self._execute(domain_name, method_name, params)
+        result = self._wait_for_result(result_id)
         if "error" in result:
             code = result["error"]["code"]
             message = result["error"]["message"]
@@ -336,12 +341,12 @@ class WSSessionManager(object):
         return result
 
     def execute_async(self, domain_name, method_name, params=None):
-        self._execute(domain_name, method_name, params)
+        result_id = self._execute(domain_name, method_name, params)
         # TODO: complete this method
         # This isn't fully implemented as we don't have a method to retrieve results
         # Also we'll need a smarter way to manage memory as there is the danger of regressing to
         # this: https://github.com/scivisum/browser-debugger-tools/pull/20/
-        return self._next_result_id
+        return result_id
 
     def _add_domain(self, domain, params):
         if domain not in self._domains:
@@ -377,7 +382,10 @@ class WSSessionManager(object):
         self._results = {}
         self._next_result_id = 0
 
-    def _wait_for_result(self):
+        self._send_queue.clear()
+        self._recv_queue.clear()
+
+    def _wait_for_result(self, result_id):
         """ Waits for a result to complete within the timeout duration then returns it.
             Raises a DevToolsTimeoutException if it cannot find the result.
 
@@ -386,7 +394,7 @@ class WSSessionManager(object):
         timer = _Timer(self.timeout)
         while not timer.timed_out:
             try:
-                return self._find_next_result()
+                return self._find_next_result(result_id)
             except ResultNotFoundError:
                 time.sleep(0.01)
         raise DevToolsTimeoutException(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="5.4.0",
+    version="6.0.0",
+    python_requires='>=3.8',
     packages=PACKAGES,
     install_requires=requires,
     license="GNU General Public License v3",
@@ -20,13 +21,12 @@ setup(
     long_description_content_type="text/markdown",
     long_description=open("README.md").read(),
     url="https://github.com/scivisum/browser-debugger-tools",
-    author="SciVisum LTD",
+    author="ThinkTribe LTD",
     author_email="rd@scivisum.co.uk",
     classifiers=[
         'Intended Audience :: Developers',
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent"
     ],

--- a/tests/integrationtests/chrome/test_interface.py
+++ b/tests/integrationtests/chrome/test_interface.py
@@ -5,33 +5,28 @@ from base64 import b64encode
 
 from mock import MagicMock, patch
 
-from browserdebuggertools.chrome.interface import ChromeInterface, _DOMManager
+from browserdebuggertools.chrome.interface import ChromeInterface
 from browserdebuggertools.exceptions import DevToolsTimeoutException
-from browserdebuggertools.wssessionmanager import WSSessionManager
+from browserdebuggertools.wssessionmanager import _WSMessageProducer
+from tests.integrationtests.test_wssessionmanager import _DummyWebsocket
 
 MODULE_PATH = "browserdebuggertools.chrome.interface."
 
 
-class MockChromeInterface(ChromeInterface):
+class ChromeInterfaceTest(TestCase):
 
-    def __init__(self, port, timeout=30, domains=None):
-        self._session_manager = MockWSSessionManager(port, timeout, domains=domains)
-        self._dom_manager = _DOMManager(self._session_manager)
-
-
-class MockWSSessionManager(WSSessionManager):
-
-    def setup_ws_session(self):
-        self.messaging_thread = MagicMock()
-        return self.messaging_thread
+    def setUp(self):
+        with patch.object(
+            _WSMessageProducer, "_get_websocket", new=MagicMock(return_value=_DummyWebsocket())
+        ):
+            self.interface = ChromeInterface(1234)
 
 
 @patch(MODULE_PATH + "ChromeInterface.execute")
-class Test_ChromeInterface_take_screenshot(TestCase):
+class Test_ChromeInterface_take_screenshot(ChromeInterfaceTest):
 
     def setUp(self):
         super(Test_ChromeInterface_take_screenshot, self).setUp()
-        self.interface = MockChromeInterface(1234)
         self.file_path = "/tmp/%s" % time.time()
 
     def test_take_screenshot(self, execute):
@@ -49,23 +44,15 @@ class Test_ChromeInterface_take_screenshot(TestCase):
             os.remove(self.file_path)
 
 
-class ChromeInterfaceTest(TestCase):
-
-    def setUp(self):
-        self.interface = MockChromeInterface(0)
-        self.interface._session_manager._recv = MagicMock()
-        self.interface._session_manager._send = MagicMock()
-
-
 class Test_ChromeInterface_set_timeout(ChromeInterfaceTest):
 
     def test_timeout_exception_raised(self):
-
-        self.interface._session_manager._recv.return_value = None
-
         start = time.time()
         with self.assertRaises(DevToolsTimeoutException):
             with self.interface.set_timeout(3):
+                def recv():
+                    time.sleep(5)
+                self.interface._session_manager._message_producer.ws.recv = recv
                 self.interface.execute("Something", "Else")
 
         elapsed = time.time() - start
@@ -77,17 +64,14 @@ class Test_ChromeInterface_get_url(ChromeInterfaceTest):
 
     def load_pages(self, count):
         mock_message = {"method": "Page.domContentEventFired"}
-        messages = [None]
         for _ in range(count):
-            messages.insert(0, mock_message)
-        self.interface._session_manager._recv.side_effect = messages
+            self.interface._session_manager._message_producer.ws.queue.append(mock_message)
 
     def load_js_pages(self, count):
         mock_message = {"method": "Page.navigatedWithinDocument", "params": {"url": ""}}
-        messages = [None]
+
         for _ in range(count):
-            messages.insert(0, mock_message)
-        self.interface._session_manager._recv.side_effect = messages
+            self.interface._session_manager._message_producer.ws.queue.append(mock_message)
 
     def test_page_enabled_cache(self):
         self.interface._session_manager._domains["Page"] = {}
@@ -106,14 +90,11 @@ class Test_ChromeInterface_get_url(ChromeInterfaceTest):
         self.assertEqual(3, self.interface._session_manager.execute.call_count)
 
         self.interface.get_url()
-        self.interface._session_manager._recv = MagicMock(return_value=None)
         self.interface.get_page_source()
-        self.interface._session_manager._recv = MagicMock(return_value=None)
-        self.assertEqual(5, self.interface._session_manager.execute.call_count)
+        self.assertEqual(4, self.interface._session_manager.execute.call_count)
 
         self.load_js_pages(1)
         self.interface.get_url()
-        self.assertEqual(5, self.interface._session_manager.execute.call_count)
-        self.interface._session_manager._recv = MagicMock(return_value=None)
+        self.assertEqual(4, self.interface._session_manager.execute.call_count)
         self.interface.get_page_source()
-        self.assertEqual(6, self.interface._session_manager.execute.call_count)
+        self.assertEqual(5, self.interface._session_manager.execute.call_count)

--- a/tests/integrationtests/test_wssessionmanager.py
+++ b/tests/integrationtests/test_wssessionmanager.py
@@ -104,8 +104,6 @@ class Test_WSSessionManager_get_events(TestCase):
             # make sure we don't lose any
             last_event_collected = events[0]
             next_event = {"method": "Network.Something", "params": {"index": -1}}
-            if self.session_manager._recv_queue:
-                next_event = json.loads(self.session_manager._recv_queue.popleft())
             first_event = {"method": "Network.Something", "params": {"index": -1}}
             if self.session_manager._events["Network"]:
                 first_event = self.session_manager._events["Network"][0]
@@ -155,8 +153,7 @@ class BlockingWS(_DummyWebsocket):
             while self._continue:
                 time.sleep(0.1)
 
-        else:
-            return super(BlockingWS, self).recv()
+        return super(BlockingWS, self).recv()
 
     def unblock(self):
         self._continue = False

--- a/tests/integrationtests/test_wssessionmanager.py
+++ b/tests/integrationtests/test_wssessionmanager.py
@@ -2,12 +2,15 @@ import json
 import socket
 import time
 from unittest import TestCase
+from multiprocessing.pool import ThreadPool
 
 import websocket
 from mock import MagicMock, patch
 
 from browserdebuggertools.exceptions import DevToolsTimeoutException, MaxRetriesException
-from browserdebuggertools.wssessionmanager import WSSessionManager, _WSMessagingThread
+from browserdebuggertools.wssessionmanager import (
+    WSSessionManager, _WSMessageProducer, NotifiableDeque
+)
 
 MODULE_PATH = "browserdebuggertools.WSSessionManager."
 
@@ -40,47 +43,101 @@ class _DummyWebsocket(object):
         raise socket.error("[Errno 11] Resource temporarily unavailable")
 
 
+class FullWebSocket(_DummyWebsocket):
+
+    def send(self, data):
+        super(FullWebSocket, self).send(data)
+        for i in range(9999):
+            result = {"method": "Network.Something", "params": {"index": i}}
+            self.queue.append(json.dumps(result))
+
+
+class Test_WSSessionManager__execute(TestCase):
+    """ It's very hard to make this test fail but it will catch major regressions
+    """
+    def setUp(self):
+        self.pool = ThreadPool(10)
+
+    def tearDown(self):
+        self.pool.close()
+
+    def continually_send(self, key):
+        for i in range(500):
+            self.session_manager._execute("foo", "bar")
+
+    def test_no_dupe_ids(self):
+        with patch.object(
+            _WSMessageProducer, "_get_websocket", new=MagicMock(return_value=_DummyWebsocket())
+        ):
+            self.session_manager = WSSessionManager(1234, 1, {"Network": {}})
+            self.ids = []
+
+            def _send(message):
+                self.ids.append(message["id"])
+
+            self.session_manager._send = _send
+
+            self.pool.map(self.continually_send, range(10))
+            time.sleep(5)
+
+            self.assertEqual(len(set(self.ids)), len(self.ids))
+
+
 class Test_WSSessionManager_get_events(TestCase):
+    """ It's very hard to make this test fail but it will catch major regressions
+    """
 
-    def test_timeout_when_getting_events(self):
+    def test_locked_get_events(self):
+        self.ws = FullWebSocket()
+        with patch.object(
+            _WSMessageProducer, "_get_websocket", new=MagicMock(return_value=self.ws)
+        ):
+            NotifiableDeque._MAX_QUEUE_BUFFER = 9999
+            self.session_manager = WSSessionManager(1234, 1, {"Network": {}})
 
-        with patch.object(_WSMessagingThread, "_get_websocket",
-                          new=MagicMock(return_value=_DummyWebsocket())):
-            self.session_manager = WSSessionManager(1234, 1)
+            events = list(reversed(self.session_manager.get_events("Network", clear=True)))
 
-            self.session_manager.enable_domain("Network")
+            while self.session_manager._message_producer.ws.queue:
+                # Wait until all messages have been processed
+                pass
 
-            def _get_from_recv_queue():
-                return json.dumps({"method": "Network.Something", "params": {}})
+            # make sure we don't lose any
+            last_event_collected = events[0]
+            next_event = {"method": "Network.Something", "params": {"index": -1}}
+            if self.session_manager._recv_queue:
+                next_event = json.loads(self.session_manager._recv_queue.popleft())
+            first_event = {"method": "Network.Something", "params": {"index": -1}}
+            if self.session_manager._events["Network"]:
+                first_event = self.session_manager._events["Network"][0]
 
-            self.session_manager.messaging_thread.get_from_recv_queue = _get_from_recv_queue
-
-            with self.assertRaises(DevToolsTimeoutException):
-                self.session_manager.get_events("Network")
+            assert (
+                last_event_collected["params"]["index"] == next_event["params"]["index"] - 1
+                or last_event_collected["params"]["index"] == first_event["params"]["index"] - 1
+            )
 
 
 class Test_WSSessionManager_wait_for_result(TestCase):
 
     def test_no_messages_with_result_timeout(self):
 
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=_DummyWebsocket())):
             self.session_manager = WSSessionManager(1234, 1)
 
             with self.assertRaises(DevToolsTimeoutException):
-                self.session_manager._wait_for_result()
+                self.session_manager._wait_for_result(99)
 
     def test_message_spamming_with_result_timeout(self):
 
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=_DummyWebsocket())):
             self.session_manager = WSSessionManager(1234, 1)
 
             with self.assertRaises(DevToolsTimeoutException):
-                self.session_manager.messaging_thread.ws.set_recv_message(
+                self.session_manager._message_producer.ws.set_recv_message(
                     {"method": "Network.Something", "params": {}}
                 )
-                self.session_manager._wait_for_result()
+                self.session_manager._wait_for_result(99)
 
 
 class BlockingWS(_DummyWebsocket):
@@ -117,6 +174,7 @@ class ExceptionThrowingWS(_DummyWebsocket):
 
         if ExceptionThrowingWS.exceptions < self.times_to_except:
             ExceptionThrowingWS.exceptions += 1
+            time.sleep(1)
             raise websocket.WebSocketConnectionClosedException()
 
         else:
@@ -128,14 +186,26 @@ class ExceptionThrowingWS(_DummyWebsocket):
 
 class Test_WSSessionManager_execute(TestCase):
 
+    def resetWS(self):
+        """ flush_messages runs async so we only want the socket to start blocking when we're
+            ready
+        """
+        ExceptionThrowingWS.exceptions = 0
+        BlockingWS.blocked = 0
+
+    def setUp(self):
+        """ We don't want the socket to block before we call execute()
+        """
+        ExceptionThrowingWS.exceptions = 2
+        BlockingWS.blocked = 2
+
     def tearDown(self):
-        self.session_manager.messaging_thread.ws.unblock()
+        self.session_manager._message_producer.ws.unblock()
         self.session_manager.close()
 
     def test_thread_blocked_once(self):
 
-        BlockingWS.blocked = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=BlockingWS(times_to_block=1))):
 
             self.session_manager = WSSessionManager(1234, 30)
@@ -143,89 +213,78 @@ class Test_WSSessionManager_execute(TestCase):
             start = time.time()
             self.session_manager.execute("Network", "enable")
 
-            # We should find the execution result after 10 seconds because
+            # We should find the execution result after 5 seconds because
             # we give the thread 5 seconds to poll before we consider it blocked,
-            # and then we give the thread a maximum of 5 seconds to finish before
-            # we replace it
-            self.assertAlmostEqual(10, time.time() - start, 0)
+            self.assertLess(time.time() - start, 10)
 
     def test_thread_blocked_twice(self):
 
-        BlockingWS.blocked = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=BlockingWS(times_to_block=2))):
 
             self.session_manager = WSSessionManager(1234, 30)
-            self.session_manager.messaging_thread.ws.blocked = 0
-
+            self.resetWS()
             start = time.time()
             self.session_manager.execute("Network", "enable")
 
-            self.assertAlmostEqual(20, time.time() - start, 0)
+            self.assertLess(time.time() - start, 15)
 
     def test_thread_blocks_causes_timeout(self):
 
-        BlockingWS.blocked = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
-                          new=MagicMock(return_value=BlockingWS())):
+        with patch.object(_WSMessageProducer, "_get_websocket",
+                          new=MagicMock(return_value=BlockingWS(times_to_block=1))):
 
             self.session_manager = WSSessionManager(1234, 3)
-            self.session_manager.messaging_thread.ws.blocked = 0
-
+            self.resetWS()
             with self.assertRaises(DevToolsTimeoutException):
                 start = time.time()
                 self.session_manager.execute("Network", "enable")
-                self.assertAlmostEqual(3, time.time() - start, 0)
+                self.assertLess(time.time() - start, 5)
 
     def test_max_thread_blocks_exceeded(self):
 
-        BlockingWS.blocked = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=BlockingWS(times_to_block=4))):
 
             self.session_manager = WSSessionManager(1234, 60)
-
+            self.resetWS()
             start = time.time()
             with self.assertRaises(MaxRetriesException):
                 self.session_manager.execute("Network", "enable")
 
-            # I cannot work out why the execute takes 55 seconds when Travis
-            # runs the test.
-            self.assertIn(int(time.time() - start), [40, 55])
+            self.assertLess(time.time() - start, 25)
 
     def test_thread_died_once(self):
 
-        ExceptionThrowingWS.exceptions = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=ExceptionThrowingWS())):
 
             self.session_manager = WSSessionManager(1234, 60)
-
+            self.resetWS()
             start = time.time()
             self.session_manager.execute("Network", "enable")
-            self.assertLess(time.time() - start, 1)
+            self.assertLess(time.time() - start, 10)
 
     def test_thread_died_twice(self):
 
-        ExceptionThrowingWS.exceptions = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=ExceptionThrowingWS(times_to_except=2))):
 
             self.session_manager = WSSessionManager(1234, 30)
-
+            self.resetWS()
             start = time.time()
             self.session_manager.execute("Network", "enable")
-            self.assertLess(time.time() - start, 1)
+            self.assertLess(time.time() - start, 10)
 
     def test_thread_died_too_many_times(self):
 
-        ExceptionThrowingWS.exceptions = 0
-        with patch.object(_WSMessagingThread, "_get_websocket",
+        with patch.object(_WSMessageProducer, "_get_websocket",
                           new=MagicMock(return_value=ExceptionThrowingWS(times_to_except=4))):
 
             self.session_manager = WSSessionManager(1234, 30)
 
+            self.resetWS()
             start = time.time()
             with self.assertRaises(MaxRetriesException):
                 self.session_manager.execute("Network", "enable")
-            self.assertLess(time.time() - start, 1)
+            self.assertLess(time.time() - start, 10)

--- a/tests/unittests/test_wssessionmanager.py
+++ b/tests/unittests/test_wssessionmanager.py
@@ -1,36 +1,49 @@
-import collections
 import copy
+import socket
+from threading import Event
 from unittest import TestCase
 
-from mock import patch, MagicMock, call
+from mock import patch, MagicMock, call, PropertyMock
 from websocket import WebSocketConnectionClosedException
 
 from browserdebuggertools.exceptions import (
-    DevToolsException, ResultNotFoundError, TabNotFoundError,
+    DevToolsException, TabNotFoundError,
     DomainNotEnabledError, DevToolsTimeoutException, MethodNotFoundError,
-    InvalidParametersError)
-from browserdebuggertools.wssessionmanager import WSSessionManager, _WSMessagingThread
+    InvalidParametersError, WebSocketBlockedException, MessagingThreadIsDeadError,
+    MaxRetriesException
+)
+from browserdebuggertools.wssessionmanager import (
+    WSSessionManager, _WSMessageProducer, NotifiableDeque
+)
 
 MODULE_PATH = "browserdebuggertools.wssessionmanager."
 
 
-class MessagingThreadTest(TestCase):
+class MockException(Exception):
+    pass
 
-    class _NoInitMessagingThread(_WSMessagingThread):
 
-        def __init__(self):
-            pass
+class WSMessageProducerTest(TestCase):
+
+    class MockWSMessageProducer(_WSMessageProducer):
+
+        def _get_websocket(self):
+            return MagicMock()
 
     def setUp(self):
-        self.messaging_thread = self._NoInitMessagingThread()
+        event = Event()
+        self.recv_queue = NotifiableDeque(event)
+        self.send_queue = NotifiableDeque(event)
+        self.messaging_thread = self.MockWSMessageProducer(1111, self.send_queue, self.recv_queue)
+        self.ws_message_producer = self.messaging_thread
 
 
 class SessionManagerTest(TestCase):
 
     class _NoWSSessionManager(WSSessionManager):
 
-        def setup_ws_session(self):
-            pass
+        def _setup_ws_session(self):
+            self._message_producer = MagicMock(is_alive=MagicMock(return_value=False))
 
     def setUp(self):
         self.session_manager = self._NoWSSessionManager(1234, 30)
@@ -38,7 +51,7 @@ class SessionManagerTest(TestCase):
 
 @patch(MODULE_PATH + "requests")
 @patch(MODULE_PATH + "websocket", MagicMock())
-class Test__WSMessagingThread__get_websocket_url(MessagingThreadTest):
+class Test___WSMessageProducer__get_websocket_url(WSMessageProducerTest):
 
     def test(self, requests):
         mock_websocket_url = "ws://localhost:1234/devtools/page/test"
@@ -67,36 +80,142 @@ class Test__WSMessagingThread__get_websocket_url(MessagingThreadTest):
             self.messaging_thread._get_websocket_url(1234)
 
 
-class Test__WSMessagingThread_run(MessagingThreadTest):
+class Test__WSMessageProducer__empty_send_queue(WSMessageProducerTest):
 
     def test(self):
+        message1, message2, message3 = MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer._send_queue.append(message1)
+        self.ws_message_producer._send_queue.append(message2)
+        self.ws_message_producer._send_queue.append(message3)
 
-        self.messaging_thread._send_queue = collections.deque()
-        self.messaging_thread._recv_queue = collections.deque()
-        self.messaging_thread._continue = True
-        self.messaging_thread._MAX_QUEUE_BUFFER = 2
+        self.ws_message_producer._empty_send_queue()
 
-        self.messaging_thread.add_to_send_queue("test1")
-        self.messaging_thread.add_to_send_queue("test2")
+        self.assertListEqual([
+            call.send(message1),
+            call.send(message2),
+            call.send(message3)
+        ], self.ws_message_producer.ws.mock_calls)
+        self.assertFalse(self.ws_message_producer._send_queue)
 
-        self.messaging_thread.ws = MagicMock()
-        self.messaging_thread.ws.send = MagicMock()
-        self.messaging_thread.close = MagicMock()
-        self.messaging_thread.ws.recv = MagicMock(side_effect=["test3", "test4"])
+    def test_fail(self):
+        message1, message2, message3 = MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer._send_queue.append(message1)
+        self.ws_message_producer._send_queue.append(message2)
+        self.ws_message_producer._send_queue.append(message3)
+        self.ws_message_producer.ws.send.side_effect = [None, MockException(), None]
 
-        def _clear():
-            self.messaging_thread._continue = False
-        self.messaging_thread._poll_signal = MagicMock(clear=_clear)
+        with self.assertRaises(MockException):
+            self.ws_message_producer._empty_send_queue()
 
-        self.messaging_thread.run()
+        self.assertListEqual([
+            call.send(message1),
+            call.send(message2),
+        ], self.ws_message_producer.ws.mock_calls)
+        self.assertListEqual([
+            message2,
+            message3,
+        ], list(self.ws_message_producer._send_queue))
 
-        self.messaging_thread.ws.send.assert_has_calls([call("test1"), call("test2")])
-        self.assertEqual("test3", self.messaging_thread.get_from_recv_queue())
-        self.assertEqual("test4", self.messaging_thread.get_from_recv_queue())
-        self.messaging_thread.close.assert_called_once_with()
+
+class Test__WSMessageProducer__empty_websocket(WSMessageProducerTest):
+
+    def test(self):
+        message1, message2, message3 = MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer.ws.recv.side_effect = [
+            message1, message2, message3,
+            socket.error("[Errno 11] Resource temporarily unavailable"),
+        ]
+
+        self.ws_message_producer._empty_websocket()
+
+        self.assertListEqual([
+            message1,
+            message2,
+            message3,
+        ], list(self.ws_message_producer._recv_queue))
+
+    def test_full(self):
+        message1, message2, message3, message4 = MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer.ws.recv.side_effect = [
+            message1, message2, message3, message4
+        ]
+        self.ws_message_producer._recv_queue._MAX_QUEUE_BUFFER = 3
+
+        self.ws_message_producer._empty_websocket()
+
+        self.assertListEqual([
+            message1,
+            message2,
+            message3,
+        ], list(self.ws_message_producer._recv_queue))
+
+    def test_other_socket_error(self):
+        message1, message2, message3 = MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer.ws.recv.side_effect = [
+            message1, message2, socket.error(), message3
+        ]
+
+        with self.assertRaises(socket.error):
+            self.ws_message_producer._empty_websocket()
+
+        self.assertListEqual([
+            message1,
+            message2,
+        ], list(self.ws_message_producer._recv_queue))
+
+    def test_fail(self):
+        message1, message2, message3 = MagicMock(), MagicMock(), MagicMock()
+        self.ws_message_producer.ws.recv.side_effect = [
+            message1, message2, MockException(), message3
+        ]
+
+        with self.assertRaises(MockException):
+            self.ws_message_producer._empty_websocket()
+
+        self.assertListEqual([
+            message1,
+            message2,
+        ], list(self.ws_message_producer._recv_queue))
 
 
-class Test__WSMessagingThread_blocked(MessagingThreadTest):
+@patch(MODULE_PATH + "time")
+@patch(MODULE_PATH + "_WSMessageProducer._empty_send_queue", MagicMock())
+@patch(MODULE_PATH + "_WSMessageProducer._empty_websocket", MagicMock())
+class Test__WSMessageProducer_run(WSMessageProducerTest):
+
+    def prepare(self, time):
+        NotifiableDeque._POLL_INTERVAL = 0
+        self.next_time = 0
+
+        def increment_time():
+            current_time = self.next_time
+            self.next_time += 1
+            if current_time == 10:
+                self.ws_message_producer.stop()
+
+            return current_time
+
+        time.time = increment_time
+
+    def test(self, time):
+        self.prepare(time)
+
+        self.ws_message_producer.run()
+
+        self.assertEqual(10, self.ws_message_producer._last_poll)
+
+    def test_exception(self, time):
+        exception = Exception()
+        self.ws_message_producer._empty_send_queue.side_effect = exception
+        self.prepare(time)
+
+        self.ws_message_producer.run()
+
+        self.assertEqual(0, self.ws_message_producer._last_poll)
+        self.assertEqual(exception, self.ws_message_producer.exception)
+
+
+class Test__WSMessagingThread_blocked(WSMessageProducerTest):
 
     def test_thread_not_started(self):
 
@@ -123,6 +242,42 @@ class Test__WSMessagingThread_blocked(MessagingThreadTest):
         self.messaging_thread._last_poll = now - self.messaging_thread._BLOCKED_TIMEOUT + 1
 
         self.assertFalse(self.messaging_thread.blocked)
+
+
+@patch(MODULE_PATH + "_WSMessageProducer.is_alive", MagicMock())
+class Test__WSMessageProducer_health_check(WSMessageProducerTest):
+
+    @patch(MODULE_PATH + "_WSMessageProducer.blocked", new_callable=PropertyMock)
+    def test_fine(self, blocked):
+        self.ws_message_producer.is_alive.return_value = True
+        blocked.return_value = False
+
+        self.ws_message_producer.health_check()
+
+    @patch(MODULE_PATH + "_WSMessageProducer.close", MagicMock())
+    @patch(MODULE_PATH + "_WSMessageProducer.blocked", new_callable=PropertyMock)
+    def test_blocked(self, blocked):
+        self.ws_message_producer.is_alive.return_value = True
+        blocked.return_value = True
+
+        with self.assertRaises(WebSocketBlockedException):
+            self.ws_message_producer.health_check()
+
+        self.ws_message_producer.close.assert_called_once_with()
+
+    def test_stopped_with_exception(self):
+        self.ws_message_producer.is_alive.return_value = False
+        self.ws_message_producer.exception = MockException()
+
+        with self.assertRaises(MockException):
+            self.ws_message_producer.health_check()
+
+    def test_stopped_no_exception(self):
+        self.ws_message_producer.is_alive.return_value = False
+        self.ws_message_producer.exception = None
+
+        with self.assertRaises(MessagingThreadIsDeadError):
+            self.ws_message_producer.health_check()
 
 
 class Test_WSSessionManager__append(SessionManagerTest):
@@ -158,7 +313,7 @@ class Test_WSSessionManager__append(SessionManagerTest):
         self.session_manager.event_handlers = {
             "MockEvent": mock_event_handler
         }
-        self.session_manager._internal_events = {"MockDomain": {"mockMethod": mock_event_handler}}
+        self.session_manager._internal_events = {"MockDomain.mockMethod": mock_event_handler}
         mock_event = {"method": "MockDomain.mockMethod", "params": MagicMock}
 
         self.session_manager._append(mock_event)
@@ -169,44 +324,52 @@ class Test_WSSessionManager__append(SessionManagerTest):
 
 class Test_WSSessionManager_flush_messages(SessionManagerTest):
 
+    def setUp(self):
+        super(Test_WSSessionManager_flush_messages, self).setUp()
+        self.session_manager._message_producer = MagicMock()
+        self.session_manager._recv_queue = NotifiableDeque()
+
+        def _check_message_producer():
+            self.session_manager._should_flush_messages = False
+        self.session_manager._check_message_producer = _check_message_producer
+
     def test_get_results(self):
-        mock_result = {"key": "value"}
-        mock_message = {"id": 1, "result": mock_result}
-        self.session_manager._recv = MagicMock(side_effect=[mock_message, None])
+        self.session_manager._recv_queue.append('{"id": 1, "result": {"key": "value"}}')
 
         self.session_manager._flush_messages()
 
-        self.assertEqual(mock_result, self.session_manager._results[1])
+        self.assertEqual({"key": "value"}, self.session_manager._results[1])
 
     def test_get_errors(self):
-        mock_message = {"id": 1, "error": {"key": "value"}}
-        self.session_manager._recv = MagicMock(side_effect=[mock_message, None])
+        self.session_manager._recv_queue.append('{"id": 1, "error": {"key": "value"}}')
 
         self.session_manager._flush_messages()
 
         self.assertEqual({"error": {"key": "value"}}, self.session_manager._results[1])
 
     def test_get_events(self):
-        mock_message = {"method": "MockDomain.mockEvent", "params": {"key": "value"}}
+        self.session_manager._recv_queue.append(
+            '{"method": "MockDomain.mockEvent", "params": {"key": "value"}}'
+        )
         self.session_manager._events["MockDomain"] = []
-        self.session_manager._recv = MagicMock(side_effect=[mock_message, None])
 
         self.session_manager._flush_messages()
 
-        self.assertIn(mock_message, self.session_manager._events["MockDomain"])
+        self.assertIn(
+            {"method": "MockDomain.mockEvent", "params": {"key": "value"}},
+            self.session_manager._events["MockDomain"]
+        )
 
     def test_get_mixed(self):
         mock_result = {"key": "value"}
         mock_error = {"error": {"key": "value"}}
         mock_event = {"method": "MockDomain.mockEvent", "params": {"key": "value"}}
-        mock_result_message = {"id": 1, "result": {"key": "value"}}
-        mock_error_message = {"id": 2, "error": {"key": "value"}}
-        mock_event_message = {"method": "MockDomain.mockEvent", "params": {"key": "value"}}
-
+        self.session_manager._recv_queue.append('{"id": 1, "result": {"key": "value"}}')
+        self.session_manager._recv_queue.append('{"id": 2, "error": {"key": "value"}}')
+        self.session_manager._recv_queue.append(
+            '{"method": "MockDomain.mockEvent", "params": {"key": "value"}}'
+        )
         self.session_manager._events["MockDomain"] = []
-        self.session_manager._recv = MagicMock(side_effect=[
-            mock_result_message, mock_error_message, mock_event_message, None
-        ])
 
         self.session_manager._flush_messages()
 
@@ -214,45 +377,12 @@ class Test_WSSessionManager_flush_messages(SessionManagerTest):
         self.assertEqual(mock_error, self.session_manager._results[2])
         self.assertIn(mock_event, self.session_manager._events["MockDomain"])
 
-    def test_timed_out(self):
+    def test_exception(self):
+        self.session_manager._check_message_producer = MagicMock(side_effect=MockException())
 
-        self.session_manager._recv = MagicMock()
+        self.session_manager._flush_messages()
 
-        with patch("browserdebuggertools.wssessionmanager._Timer", new=MagicMock(timed_out=True)):
-            with self.assertRaises(DevToolsTimeoutException):
-                self.session_manager._flush_messages()
-
-
-@patch(MODULE_PATH + "WSSessionManager._flush_messages", MagicMock())
-class Test_WSSessionManager_find_next_result(SessionManagerTest):
-
-    def test_find_cached_result(self):
-        mock_result = {"result": "correct result"}
-
-        self.session_manager._next_result_id = 42
-        self.session_manager._results[42] = mock_result
-        result = self.session_manager._find_next_result()
-
-        self.assertEqual(mock_result, result)
-
-    def test_find_uncached_result(self):
-
-        mock_result = {"result": "correct result"}
-        self.session_manager._results = {}
-        self.session_manager._next_result_id = 42
-
-        def mock_flush_messages():
-            self.session_manager._results[42] = mock_result
-
-        self.session_manager._flush_messages = mock_flush_messages
-
-        result = self.session_manager._find_next_result()
-        self.assertEqual(mock_result, result)
-
-    def test_no_result(self):
-
-        with self.assertRaises(ResultNotFoundError):
-            self.session_manager._find_next_result()
+        self.assertIsInstance(self.session_manager._exception, MockException)
 
 
 @patch(MODULE_PATH + "websocket.send", MagicMock())
@@ -270,9 +400,9 @@ class Test_WSSessionManager_execute(SessionManagerTest):
         self.session_manager.execute(domain, method, None)
 
         self.assertEqual(4, self.session_manager._next_result_id)
-        self.session_manager._wait_for_result.assert_called_once_with()
+        self.session_manager._wait_for_result.assert_called_once_with(4)
         self.session_manager._send.assert_called_once_with({
-            "method": "%s.%s" % (domain, method), "params": {}
+            "id": 4, "method": "%s.%s" % (domain, method), "params": {}
         })
 
     @patch(MODULE_PATH + "WSSessionManager._execute", new=MagicMock())
@@ -347,7 +477,6 @@ class Test_WSSessionManager_get_events(SessionManagerTest):
 
         events = self.session_manager.get_events(self.domain)
 
-        _flush_messages.assert_called_once_with()
         self.assertEqual(self.mock_events[self.domain], events)
         self.assertEqual(self.mock_events, self.session_manager._events)
 
@@ -364,12 +493,11 @@ class Test_WSSessionManager_get_events(SessionManagerTest):
 
         events = self.session_manager.get_events(self.domain, clear=True)
 
-        _flush_messages.assert_called_once_with()
         self.assertEqual(self.mock_events[self.domain], events)
         self.assertEqual([], self.session_manager._events[self.domain])
 
 
-class Test_wssessionmanager_clear_all_events(SessionManagerTest):
+class Test_wssessionmanager_reset(SessionManagerTest):
 
     def test(self):
         self.session_manager.domains = ["Page", "Network"]
@@ -377,11 +505,19 @@ class Test_wssessionmanager_clear_all_events(SessionManagerTest):
             "Page": [MagicMock(), MagicMock()],
             "Network": [MagicMock(), MagicMock()]
         }
+        self.session_manager._results = {1: MagicMock()}
+        self.session_manager._next_result_id = 2
+        self.session_manager._send_queue.append(MagicMock())
+        self.session_manager._recv_queue.append(MagicMock())
 
         self.session_manager.reset()
 
         for key, value in self.session_manager._events.items():
             self.assertEqual([], value)
+        self.assertFalse(self.session_manager._results)
+        self.assertEqual(0, self.session_manager._next_result_id)
+        self.assertFalse(self.session_manager._send_queue)
+        self.assertFalse(self.session_manager._recv_queue)
 
 
 @patch(MODULE_PATH + "WSSessionManager.execute")
@@ -421,97 +557,118 @@ class Test_WSSessionManager_enable_domain(SessionManagerTest):
 
 class Test_WSSessionManager_wait_for_result(SessionManagerTest):
 
-    @patch("browserdebuggertools.wssessionmanager._Timer",
-           new=MagicMock(return_value=MagicMock(timed_out=False)))
+    @patch(MODULE_PATH + "_Timer", new=MagicMock(return_value=MagicMock(timed_out=False)))
     def test_succeed_immediately(self):
         mock_result = MagicMock()
-        self.session_manager._find_next_result = MagicMock()
-        self.session_manager._find_next_result.side_effect = [mock_result]
+        self.session_manager._results[1] = mock_result
 
-        result = self.session_manager._wait_for_result()
+        result = self.session_manager._wait_for_result(1)
         self.assertEqual(mock_result, result)
 
-    @patch("browserdebuggertools.wssessionmanager._Timer",
-           new=MagicMock(return_value=MagicMock(timed_out=False)))
-    def test_wait_and_then_succeeed(self):
-
+    @patch(MODULE_PATH + "time")
+    @patch(MODULE_PATH + "_Timer", new=MagicMock(return_value=MagicMock(timed_out=False)))
+    def test_wait_and_then_succeeed(self, time):
         mock_result = MagicMock()
-        self.session_manager._find_next_result = MagicMock()
-        self.session_manager._find_next_result.side_effect = [ResultNotFoundError, mock_result]
+        self.session_manager._results = {}
+
+        def sleep(wait):
+            self.session_manager._results[1] = mock_result
+
+        time.sleep = sleep
+
         self.session_manager.timer = MagicMock(timed_out=False)
 
-        result = self.session_manager._wait_for_result()
+        result = self.session_manager._wait_for_result(1)
 
         self.assertEqual(mock_result, result)
 
-    @patch("browserdebuggertools.wssessionmanager._Timer",
-           new=MagicMock(return_value=MagicMock(timed_out=True)))
+    @patch(MODULE_PATH + "_Timer", new=MagicMock(return_value=MagicMock(timed_out=True)))
     def test_timed_out(self):
-
-        self.session_manager._recv = MagicMock()
         self.session_manager.timer = MagicMock(timed_out=True)
         with self.assertRaises(DevToolsTimeoutException):
-            self.session_manager._wait_for_result()
+            self.session_manager._wait_for_result(1)
 
 
-class Test_WSSessionManager__check_messaging_thread(SessionManagerTest):
+@patch(MODULE_PATH + "WSSessionManager._increment_message_producer_not_ok")
+class Test_WSSessionManager__check_message_producer(SessionManagerTest):
 
-    def test_ok(self):
+    def setUp(self):
+        super(Test_WSSessionManager__check_message_producer, self).setUp()
+        self.session_manager._setup_ws_session = MagicMock()
 
-        self.session_manager.messaging_thread = MagicMock(
-            is_alive=MagicMock(return_value=True), blocked=False
-        )
-        self.session_manager.setup_ws_session = MagicMock()
-        self.session_manager.increment_messaging_thread_not_ok = MagicMock()
+    def test_ok(self, _increment_message_producer_not_ok):
+        self.session_manager._recv_queue = MagicMock()
 
-        self.session_manager._check_messaging_thread()
+        self.session_manager._check_message_producer()
 
-        self.session_manager.setup_ws_session.assert_not_called()
-        self.session_manager.increment_messaging_thread_not_ok.assert_not_called()
+        self.session_manager._recv_queue.wait_for_messages.assert_called_once_with()
 
-    def test_blocked(self):
-        self.session_manager.messaging_thread = MagicMock(
-            is_alive=MagicMock(return_value=True), blocked=True
-        )
-        self.session_manager.setup_ws_session = MagicMock()
-        self.session_manager.increment_messaging_thread_not_ok = MagicMock()
-        self.session_manager.close = MagicMock()
+    def test_ws_closed(self, _increment_message_producer_not_ok):
+        self.session_manager._message_producer.health_check.side_effect = \
+            WebSocketConnectionClosedException
 
-        self.session_manager._check_messaging_thread()
+        self.session_manager._check_message_producer()
 
-        self.session_manager.setup_ws_session.assert_called_once_with()
-        self.session_manager.increment_messaging_thread_not_ok.assert_called_once_with()
-        self.session_manager.close.assert_called_once_with()
+        self.session_manager._increment_message_producer_not_ok.assert_called_once_with()
+        self.session_manager._setup_ws_session.assert_called_once_with()
 
-    def test_dead_because_connection_closed(self):
-        self.session_manager.messaging_thread = MagicMock(
-            is_alive=MagicMock(return_value=False), blocked=False
-        )
-        self.session_manager.setup_ws_session = MagicMock()
-        self.session_manager.increment_messaging_thread_not_ok = MagicMock()
-        self.session_manager.close = MagicMock()
-        self.session_manager.messaging_thread.exception = WebSocketConnectionClosedException()
+    def test_ws_blocked(self, _increment_message_producer_not_ok):
+        self.session_manager._message_producer.health_check.side_effect = WebSocketBlockedException
 
-        self.session_manager._check_messaging_thread()
+        self.session_manager._check_message_producer()
 
-        self.session_manager.setup_ws_session.assert_called_once_with()
-        self.session_manager.increment_messaging_thread_not_ok.assert_called_once_with()
+        self.session_manager._increment_message_producer_not_ok.assert_called_once_with()
+        self.session_manager._setup_ws_session.assert_called_once_with()
 
-    def test_dead_because_other(self):
-        self.session_manager.messaging_thread = MagicMock(
-            is_alive=MagicMock(return_value=False), blocked=False
-        )
-        self.session_manager.setup_ws_session = MagicMock()
-        self.session_manager.increment_messaging_thread_not_ok = MagicMock()
-        self.session_manager.close = MagicMock()
+    def test_other_failure(self, _increment_message_producer_not_ok):
+        self.session_manager._message_producer.health_check.side_effect = MockException()
 
-        class TestException(Exception):
-            pass
+        with self.assertRaises(MockException):
+            self.session_manager._check_message_producer()
 
-        self.session_manager.messaging_thread.exception = TestException()
 
-        with self.assertRaises(TestException):
-            self.session_manager._check_messaging_thread()
+@patch(MODULE_PATH + "time.time", MagicMock(return_value=100))
+class Test_WSSessionManager__increment_message_producer_not_ok(SessionManagerTest):
 
-        self.session_manager.setup_ws_session.assert_not_called()
-        self.session_manager.increment_messaging_thread_not_ok.assert_not_called()
+    def setUp(self):
+        super(Test_WSSessionManager__increment_message_producer_not_ok, self).setUp()
+        self.session_manager.MAX_RETRY_THREADS = 3
+        self.session_manager.RETRY_COUNT_TIMEOUT = 300
+
+    def test_first_run_on_ws(self):
+        self.session_manager._last_not_ok = None
+
+        self.session_manager._increment_message_producer_not_ok()
+
+        self.assertEqual(100, self.session_manager._last_not_ok)
+        self.assertEqual(1, self.session_manager._message_producer_not_ok_count)
+
+    def test_increment(self):
+        self.session_manager._last_not_ok = 49
+        self.session_manager._message_producer_not_ok_count = 1
+
+        self.session_manager._increment_message_producer_not_ok()
+
+        self.assertEqual(100, self.session_manager._last_not_ok)
+        self.assertEqual(2, self.session_manager._message_producer_not_ok_count)
+
+    def test_timeout_expired(self):
+        self.session_manager.RETRY_COUNT_TIMEOUT = 50
+        self.session_manager._last_not_ok = 49
+        self.session_manager._message_producer_not_ok_count = 3
+
+        self.session_manager._increment_message_producer_not_ok()
+
+        self.assertEqual(100, self.session_manager._last_not_ok)
+        self.assertEqual(1, self.session_manager._message_producer_not_ok_count)
+
+    def test_exceeded_max_failures(self):
+        self.session_manager._last_not_ok = 49
+        self.session_manager._message_producer_not_ok_count = 3
+        self.session_manager._exception = None
+
+        with self.assertRaises(MaxRetriesException):
+            self.session_manager._increment_message_producer_not_ok()
+
+        self.assertEqual(100, self.session_manager._last_not_ok)
+        self.assertEqual(4, self.session_manager._message_producer_not_ok_count)


### PR DESCRIPTION
Context for not using queue.Queue

https://stackoverflow.com/questions/717148/queue-queue-vs-collections-deque

Here's a quick benchmark I did
```
import time
import queue
import collections
from browserdebuggertools.wssessionmanager import NotifiableDeque

q = collections.deque()
t0 = time.time()
for i in range(100000):
    q.append(1)
t1 = time.time()
for i in range(100000):
    q.popleft()
t2 = time.time()
print("deque(insert: {}, pop: {}, total: {})".format(t1-t0, t2-t1, t2-t0))


q = queue.Queue(100000)
t0 = time.time()
for i in range(100000):
    q.put(1)
t1 = time.time()
for i in range(100000):
    q.get()
t2 = time.time()
print("Queue(insert: {}, pop: {}, total: {})".format(t1-t0, t2-t1, t2-t0))

q = NotifiableDeque()
t0 = time.time()
for i in range(100000):
    q.append(1)
t1 = time.time()
for i in range(100000):
    q.popleft()
t2 = time.time()
print("NotifiableDeque(insert: {}, pop: {}, total: {})".format(t1-t0, t2-t1, t2-t0))


deque(insert: 0.014841079711914062, pop: 0.008016347885131836, total: 0.0228574275970459)
Queue(insert: 0.21514225006103516, pop: 0.16381311416625977, total: 0.3789553642272949)
NotifiableDeque(insert: 0.20758509635925293, pop: 0.008402824401855469, total: 0.2159879207611084)
```

Since insertion operations set an event they are a lot slower than a collections.deque but still a little faster than queue.Queue. The time saved is mainly in where we remove from the queue since we know only one thread will do this we don't need the safety that queue.Queue provides.