### PR TITLE
[RD-41645] Use a threading Event to speed up message polling

### DIFF
--- a/browserdebuggertools/chrome/interface.py
+++ b/browserdebuggertools/chrome/interface.py
@@ -90,7 +90,7 @@ class ChromeInterface(object):
             self._session_manager.timeout = _timeout
 
     def navigate(self, url):
-        """ Navigates to the given url asynchronously
+        """ Navigates to the given url
         """
         return self.execute("Page", "navigate", {
             "url": url

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="6.0.1",
+    version="6.0.2",
     python_requires='>=3.8',
     packages=PACKAGES,
     install_requires=requires,


### PR DESCRIPTION
- When we execute some method, we can speed up the polling whilst
we wait for the result; otherwise use a higher interval time of 1 second.