### PR TITLE
#42 Make a chrome extension for blocking/unblocking main frame requests

### DIFF
--- a/browserdebuggertools/chrome/chromeExtensions/requestBlocker/contentScript.js
+++ b/browserdebuggertools/chrome/chromeExtensions/requestBlocker/contentScript.js
@@ -1,0 +1,5 @@
+
+(async () => {
+  const response = await chrome.runtime.sendMessage({method: "getExtensionID"});
+  localStorage.setItem("requestBlockerExtensionID", response.result);
+})();

--- a/browserdebuggertools/chrome/chromeExtensions/requestBlocker/manifest.json
+++ b/browserdebuggertools/chrome/chromeExtensions/requestBlocker/manifest.json
@@ -1,0 +1,29 @@
+{
+  "manifest_version": 3,
+  "name": "Request Blocker",
+  "description": "Request Blocker",
+  "version": "1.0",
+  "permissions": [
+    "declarativeNetRequest"
+  ],
+ "declarative_net_request" : {
+    "rule_resources" : [{
+      "id": "blockMainFrames",
+      "enabled": false,
+      "path": "ruleset.json"
+    }]
+  },
+  "host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "requestBlocker.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"]
+    }
+  ],
+  "externally_connectable": {
+    "matches": ["*://*/*"]
+  }
+}

--- a/browserdebuggertools/chrome/chromeExtensions/requestBlocker/requestBlocker.js
+++ b/browserdebuggertools/chrome/chromeExtensions/requestBlocker/requestBlocker.js
@@ -1,0 +1,44 @@
+function blockMainFrames() {
+    chrome.declarativeNetRequest.updateEnabledRulesets(
+        {
+      disableRulesetIds: [],
+      enableRulesetIds:["blockMainFrames"]
+        },
+        () => {console.log("Blocked main frames")}
+    );
+}
+
+
+function unblockMainFrames() {
+    chrome.declarativeNetRequest.updateEnabledRulesets(
+        {
+      disableRulesetIds: ["blockMainFrames"],
+      enableRulesetIds:[]
+        },
+        () => {console.log("unblocked main frames")}
+    );
+}
+
+
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    if (request.method === "getExtensionID") {
+        sendResponse({result: chrome.runtime.id});
+    }
+    else {
+        console.log("Unexpected method: " + request.method);
+    }
+});
+
+
+chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+   if (request.method === "blockMainFrames") {
+        blockMainFrames();
+        sendResponse({result: "success"});
+    }
+    else if (request.method === "unblockMainFrames") {
+        unblockMainFrames();
+        sendResponse({result: "success"});
+    } else {
+      console.log("Unexpected method: " + request.method);
+   }
+});

--- a/browserdebuggertools/chrome/chromeExtensions/requestBlocker/ruleset.json
+++ b/browserdebuggertools/chrome/chromeExtensions/requestBlocker/ruleset.json
@@ -1,0 +1,6 @@
+[{
+  "id": 1,
+  "priority": 1,
+  "action": {"type": "block"},
+  "condition": {"resourceTypes": ["main_frame"]}
+}]


### PR DESCRIPTION
- The rules apply to all tabs, including new ones.
- Only "main frames" are affected. So resources can continue to be loaded for pages already opened in other tabs.
- Explicitly keep the service worker alive, so that we can attach a debugger to it.