### PR TITLE
[RD-49887] Fix deadlock.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="6.1.0",
+    version="6.1.1",
     python_requires='>=3.8',
     packages=PACKAGES,
     install_requires=requires,


### PR DESCRIPTION
If we try to execute a command, it will take the lock while checking the health. If the websocket is blocked or closed it will try to recreate the web socket and message processing thread under that lock. After recreating the websocket it will execute more commands if it is supposed to have some domains enabled. That execute command will also try to check the health of the message producer which will then deadlock on the message producer lock. So make the lock re-entrant, so the same thread can execute commands under the message process lock.

Also before starting a new websocket, ensure the old one is closed.