### PR TITLE
Make execute_javascript throw a JavascriptError if the javascript fai…

### DIFF
--- a/browserdebuggertools/exceptions.py
+++ b/browserdebuggertools/exceptions.py
@@ -41,6 +41,10 @@ class JavascriptDialogNotFoundError(NotFoundError):
     pass
 
 
+class JavascriptError(DevToolsException):
+    pass
+
+
 class MaxRetriesException(DevToolsException):
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="6.2.1",
+    version="6.2.2",
     python_requires='>=3.8',
     include_package_data=True,
     packages=PACKAGES,

--- a/tests/e2etests/chrome/test_interface.py
+++ b/tests/e2etests/chrome/test_interface.py
@@ -563,9 +563,15 @@ class SwitchTabTest(ChromeInterfaceTest):
 
         # Block any new document requests and open url in a new tab
         self.devtools_client.block_main_frames()
-        self.devtools_client.execute_javascript(
-            f"window.open('http://localhost:{self.testSite.port}/simple_page_2', '_blank')",
-            returnByValue=False, userGesture=True
+        # In Chrome 112 for some reason we can't specify useGesture and returnByValue at the same
+        # time, if we do we get an 'Object reference chain is too long' error.
+        # So don't use execute_javascript which insists on setting returnByValue.
+        self.devtools_client.execute(
+            "Runtime", "evaluate",
+            {
+                "expression": f"window.open('http://localhost:{self.testSite.port}/simple_page_2', '_blank')",
+                "userGesture": True
+            }
         )
 
         # Initially the title of the new tab is equal to the URL, but if we wait a bit it will


### PR DESCRIPTION
…led.

- Require this interface to use returnByValue = True, because we want to help the user by getting the value out of the result object.
- We should either use returnByValue or return the result not the value. I chose the latter because that's what any existing user expects it to do.