### PR TITLE
[RD-53128] Upgrade jinja2 package to match version in tribe-mono

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,5 @@
 requests==2.31.0
-jinja2==3.1.3
+jinja2==3.1.5
 pytest==7.3.1
 websocket-client==1.5.1
 cherrypy==18.8.0

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ PACKAGES = find_packages(include="browserdebuggertools*")
 
 setup(
     name="browserdebuggertools",
-    version="6.2.3",
+    version="6.2.4",
     python_requires='>=3.8',
     include_package_data=True,
     packages=PACKAGES,


### PR DESCRIPTION
This is not the latest version, but I've upgraded the package in tribe-mono to this version so I thought it would be best to keep it consistent. 